### PR TITLE
Rename module to ear

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/veraison/ar4si
+module github.com/veraison/ear
 
 go 1.18
 


### PR DESCRIPTION
This module now implements the EAT Attestation Result (ear) in addition
to just what is defined by ar4si standard, so rename the module
appropriately.