### PR TITLE
Rename module to ear + convert profile to valid tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 export GO111MODULE := on
 export SHELL := /bin/bash
 
-GOPKG := github.com/veraison/ar4si
-GOPKG += github.com/veraison/ar4si/arc/cmd
+GOPKG := github.com/veraison/ear
+GOPKG += github.com/veraison/ear/arc/cmd
 
 GOLINT ?= golangci-lint
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![ci](https://github.com/veraison/ar4si/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/veraison/ar4si/actions/workflows/ci.yml)
 [![cover ≥90.0%](https://github.com/veraison/ar4si/actions/workflows/ci-go-cover.yml/badge.svg?branch=main)](https://github.com/veraison/ar4si/actions/workflows/ci-go-cover.yml)
 
-The `ar4si` package provides a golang API for working with EAR (EAT Attesation Result), an EAT/JWT serialisation of the [Attestation Result for Secure Interactions (AR4SI)](https://datatracker.ietf.org/doc/draft-ietf-rats-ar4si/) information model.
+The `ear` package provides a golang API for working with EAR (EAT Attesation Result), an EAT/JWT serialisation of the [Attestation Result for Secure Interactions (AR4SI)](https://datatracker.ietf.org/doc/draft-ietf-rats-ar4si/) information model.
 
 A command line interface utility ([`arc`](arc/README.md)) is also provided to create, verify and display EAR attestation result payloads. To install it:
 

--- a/arc/cmd/create.go
+++ b/arc/cmd/create.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/ar4si"
+	"github.com/veraison/ear"
 )
 
 var (
@@ -35,10 +35,10 @@ the key in the default key file "skey.json", and save the result to "my-ear.jwt"
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				claimsSet, sKey, ear []byte
-				sigK                 jwk.Key
-				ar                   ar4si.AttestationResult
-				err                  error
+				claimsSet, sKey, arBytes []byte
+				sigK                     jwk.Key
+				ar                       ear.AttestationResult
+				err                      error
 			)
 
 			if err = checkCreateArgs(args); err != nil {
@@ -64,12 +64,12 @@ the key in the default key file "skey.json", and save the result to "my-ear.jwt"
 				return fmt.Errorf("parsing signing key from %q: %w", createSKey, err)
 			}
 
-			if ear, err = ar.Sign(jwa.KeyAlgorithmFrom(createAlg), sigK); err != nil {
+			if arBytes, err = ar.Sign(jwa.KeyAlgorithmFrom(createAlg), sigK); err != nil {
 				return fmt.Errorf("signing EAR: %w", err)
 			}
 
 			// save to createOutput
-			if err = afero.WriteFile(fs, createOutput, ear, 0644); err != nil {
+			if err = afero.WriteFile(fs, createOutput, arBytes, 0644); err != nil {
 				return fmt.Errorf("saving signer EAR to file %q: %w", createOutput, err)
 			}
 

--- a/arc/cmd/test_vars.go
+++ b/arc/cmd/test_vars.go
@@ -20,9 +20,9 @@ var (
 	testEmptyClaimsSet = []byte(`{}`)
 	testMiniClaimsSet  = []byte(`{
     "ear.status": "affirming",
-    "eat_profile": "tag:github.com/veraison/ar4si,2022-10-17",
+    "eat_profile": "tag:github.com,2022:veraison/ear",
     "iat": 1666091373,
     "ear.appraisal-policy-id": "https://veraison.example/policy/1/60a0068d"
 }`)
-	testJWT = []byte(`eyJhbGciOiJFUzI1NiJ9.eyJlYXIuc3RhdHVzIjoiYWZmaXJtaW5nIiwiZWF0X3Byb2ZpbGUiOiJ0YWc6Z2l0aHViLmNvbS92ZXJhaXNvbi9hcjRzaSwyMDIyLTEwLTE3IiwiZWFyLnRydXN0d29ydGhpbmVzcy12ZWN0b3IiOnsiaW5zdGFuY2UtaWRlbnRpdHkiOjIsImNvbmZpZ3VyYXRpb24iOjIsImV4ZWN1dGFibGVzIjozLCJmaWxlLXN5c3RlbSI6MiwiaGFyZHdhcmUiOjIsInJ1bnRpbWUtb3BhcXVlIjoyLCJzdG9yYWdlLW9wYXF1ZSI6Miwic291cmNlZC1kYXRhIjoyfSwiZWFyLnJhdy1ldmlkZW5jZSI6IjNxMis3dz09IiwiaWF0IjoxNjY2MDkxMzczLCJlYXIuYXBwcmFpc2FsLXBvbGljeS1pZCI6Imh0dHBzOi8vdmVyYWlzb24uZXhhbXBsZS9wb2xpY3kvMS82MGEwMDY4ZCJ9.p0qLmOjCJchaMAiMQdFla_CWCzlcaY_dlUTjMhOTZJvKfyibsDKVSIPNJ-bxT7PpsjKDHwCGHggbihw68iZ5UA`)
+	testJWT = []byte(`eyJhbGciOiJFUzI1NiJ9.eyJlYXIuc3RhdHVzIjoiYWZmaXJtaW5nIiwiZWF0X3Byb2ZpbGUiOiJ0YWc6Z2l0aHViLmNvbSwyMDIyOnZlcmFpc29uL2VhciIsImVhci50cnVzdHdvcnRoaW5lc3MtdmVjdG9yIjp7Imluc3RhbmNlLWlkZW50aXR5IjoyLCJjb25maWd1cmF0aW9uIjoyLCJleGVjdXRhYmxlcyI6MywiZmlsZS1zeXN0ZW0iOjIsImhhcmR3YXJlIjoyLCJydW50aW1lLW9wYXF1ZSI6Miwic3RvcmFnZS1vcGFxdWUiOjIsInNvdXJjZWQtZGF0YSI6Mn0sImVhci5yYXctZXZpZGVuY2UiOiIzcTIrN3c9PSIsImlhdCI6MTY2NjA5MTM3MywiZWFyLmFwcHJhaXNhbC1wb2xpY3ktaWQiOiJodHRwczovL3ZlcmFpc29uLmV4YW1wbGUvcG9saWN5LzEvNjBhMDA2OGQifQ.ZA_UPhIYr6n4e5h56jPieVDs6Zu39cI1fwrfqWKbZ9k0iXSt7ikEj4mlfW3RZX-_UYDI234JE7L-caltAtaRow`)
 )

--- a/arc/cmd/verify.go
+++ b/arc/cmd/verify.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/ar4si"
+	"github.com/veraison/ear"
 )
 
 var (
@@ -37,10 +37,10 @@ embedded EAR claims-set and present a report of the trustworthiness vector.
 	`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var (
-				claimsSet, pKey, ear []byte
-				vfyK                 jwk.Key
-				ar                   ar4si.AttestationResult
-				err                  error
+				claimsSet, pKey, arBytes []byte
+				vfyK                     jwk.Key
+				ar                       ear.AttestationResult
+				err                      error
 			)
 
 			if err = checkVerifyArgs(args); err != nil {
@@ -49,7 +49,7 @@ embedded EAR claims-set and present a report of the trustworthiness vector.
 
 			verifyInput = args[0]
 
-			if ear, err = afero.ReadFile(fs, verifyInput); err != nil {
+			if arBytes, err = afero.ReadFile(fs, verifyInput); err != nil {
 				return fmt.Errorf("loading signed EAR from %q: %w", verifyInput, err)
 			}
 
@@ -62,7 +62,7 @@ embedded EAR claims-set and present a report of the trustworthiness vector.
 				return fmt.Errorf("parsing verification key from %q: %w", verifyPKey, err)
 			}
 
-			if err = ar.Verify(ear, jwa.KeyAlgorithmFrom(verifyAlg), vfyK); err != nil {
+			if err = ar.Verify(arBytes, jwa.KeyAlgorithmFrom(verifyAlg), vfyK); err != nil {
 				return fmt.Errorf("verifying signed EAR from %s: %w", verifyInput, err)
 			}
 

--- a/arc/data/ear-claims-tv-ok.json
+++ b/arc/data/ear-claims-tv-ok.json
@@ -1,6 +1,6 @@
 {
     "ear.status": "affirming",
-    "eat_profile": "tag:github.com/veraison/ar4si,2022-10-17",
+    "eat_profile": "tag:github.com,2022:veraison/ear",
     "ear.trustworthiness-vector": {
         "instance-identity": 2,
         "configuration": 2,

--- a/arc/data/ear-claims.json
+++ b/arc/data/ear-claims.json
@@ -1,6 +1,6 @@
 {
     "ear.status": "affirming",
-    "eat_profile": "tag:github.com/veraison/ar4si,2022-10-17",
+    "eat_profile": "tag:github.com,2022:veraison/ear",
     "iat": 1666091373,
     "ear.appraisal-policy-id": "https://veraison.example/policy/1/60a0068d"
 }

--- a/arc/main.go
+++ b/arc/main.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package main
 
-import "github.com/veraison/ar4si/arc/cmd"
+import "github.com/veraison/ear/arc/cmd"
 
 func main() {
 	cmd.Execute()

--- a/doc.go
+++ b/doc.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /*
-Package ar4si implements an EAT attestation result format based on the
+Package ear implements an EAT attestation result format based on the
 information model defined in
 https://datatracker.ietf.org/doc/draft-ietf-rats-ar4si/
 
@@ -101,4 +101,4 @@ printout, as well as using colors when displaying the claims' values.
 
 	fmt.Print(ar.TrustVector.Report(short, color))
 */
-package ar4si
+package ear

--- a/ear.go
+++ b/ear.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package ar4si
+package ear
 
 import (
 	"encoding/json"
@@ -14,7 +14,7 @@ import (
 )
 
 // EatProfile is the EAT profile implemented by this package
-const EatProfile = "tag:github.com/veraison/ar4si,2022-10-17"
+const EatProfile = "tag:github.com,2022:veraison/ear"
 
 // TrustTier represents the overall state of an evidence appraisal.
 //

--- a/ear_test.go
+++ b/ear_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package ar4si
+package ear
 
 import (
 	"fmt"
@@ -215,7 +215,7 @@ func TestFromJSON_fail(t *testing.T) {
 		},
 		{
 			ar:       `[]`,
-			expected: `json: cannot unmarshal array into Go value of type ar4si.AttestationResult`,
+			expected: `json: cannot unmarshal array into Go value of type ear.AttestationResult`,
 		},
 		{
 			ar:       `{}`,
@@ -234,9 +234,9 @@ func TestFromJSON_fail(t *testing.T) {
 func TestVerify_pass(t *testing.T) {
 	tvs := []string{
 		// ok
-		`eyJhbGciOiJFUzI1NiJ9.eyJlYXIuc3RhdHVzIjoiYWZmaXJtaW5nIiwiZWF0X3Byb2ZpbGUiOiJ0YWc6Z2l0aHViLmNvbS92ZXJhaXNvbi9hcjRzaSwyMDIyLTEwLTE3IiwiaWF0IjoxNjY2MDkxMzczLCJlYXIuYXBwcmFpc2FsLXBvbGljeS1pZCI6Imh0dHBzOi8vdmVyYWlzb24uZXhhbXBsZS9wb2xpY3kvMS82MGEwMDY4ZCIsImVhci52ZXJhaXNvbi5wcm9jZXNzZWQtZXZpZGVuY2UiOnsiazEiOiJ2MSIsImsyIjoidjIifSwiZWFyLnZlcmFpc29uLnZlcmlmaWVyLWFkZGVkLWNsYWltcyI6eyJiYXIiOiJiYXoiLCJmb28iOiJiYXIifX0.horFZfZW49Sm9-tNU1A-W_qp9275B55idoDIe8zhHXqKizjodtXQh8FRU9B-TplM37lk38MomNvt1z3d8QaDjg`,
+		`eyJhbGciOiJFUzI1NiJ9.eyJlYXIuc3RhdHVzIjoiYWZmaXJtaW5nIiwiZWF0X3Byb2ZpbGUiOiJ0YWc6Z2l0aHViLmNvbSwyMDIyOnZlcmFpc29uL2VhciIsImlhdCI6MTY2NjA5MTM3MywiZWFyLmFwcHJhaXNhbC1wb2xpY3ktaWQiOiJodHRwczovL3ZlcmFpc29uLmV4YW1wbGUvcG9saWN5LzEvNjBhMDA2OGQiLCJlYXIudmVyYWlzb24ucHJvY2Vzc2VkLWV2aWRlbmNlIjp7ImsxIjoidjEiLCJrMiI6InYyIn0sImVhci52ZXJhaXNvbi52ZXJpZmllci1hZGRlZC1jbGFpbXMiOnsiYmFyIjoiYmF6IiwiZm9vIjoiYmFyIn19.P0yB2s_DmCQ7DSX2pOnyKbNMVCfTrqkxohWrDxwBdKqOMrrXoCYJmWlpgwtHV-AA56NXMRObeZk9zT_0TlPgpQ`,
 		// ok with trailing stuff (ignored)
-		`eyJhbGciOiJFUzI1NiJ9.eyJlYXIuc3RhdHVzIjoiYWZmaXJtaW5nIiwiZWF0X3Byb2ZpbGUiOiJ0YWc6Z2l0aHViLmNvbS92ZXJhaXNvbi9hcjRzaSwyMDIyLTEwLTE3IiwiaWF0IjoxNjY2MDkxMzczLCJlYXIuYXBwcmFpc2FsLXBvbGljeS1pZCI6Imh0dHBzOi8vdmVyYWlzb24uZXhhbXBsZS9wb2xpY3kvMS82MGEwMDY4ZCIsImVhci52ZXJhaXNvbi5wcm9jZXNzZWQtZXZpZGVuY2UiOnsiazEiOiJ2MSIsImsyIjoidjIifSwiZWFyLnZlcmFpc29uLnZlcmlmaWVyLWFkZGVkLWNsYWltcyI6eyJiYXIiOiJiYXoiLCJmb28iOiJiYXIifX0.horFZfZW49Sm9-tNU1A-W_qp9275B55idoDIe8zhHXqKizjodtXQh8FRU9B-TplM37lk38MomNvt1z3d8QaDjg.trailing-rubbish-is-ignored`,
+		`eyJhbGciOiJFUzI1NiJ9.eyJlYXIuc3RhdHVzIjoiYWZmaXJtaW5nIiwiZWF0X3Byb2ZpbGUiOiJ0YWc6Z2l0aHViLmNvbSwyMDIyOnZlcmFpc29uL2VhciIsImlhdCI6MTY2NjA5MTM3MywiZWFyLmFwcHJhaXNhbC1wb2xpY3ktaWQiOiJodHRwczovL3ZlcmFpc29uLmV4YW1wbGUvcG9saWN5LzEvNjBhMDA2OGQiLCJlYXIudmVyYWlzb24ucHJvY2Vzc2VkLWV2aWRlbmNlIjp7ImsxIjoidjEiLCJrMiI6InYyIn0sImVhci52ZXJhaXNvbi52ZXJpZmllci1hZGRlZC1jbGFpbXMiOnsiYmFyIjoiYmF6IiwiZm9vIjoiYmFyIn19.P0yB2s_DmCQ7DSX2pOnyKbNMVCfTrqkxohWrDxwBdKqOMrrXoCYJmWlpgwtHV-AA56NXMRObeZk9zT_0TlPgpQ.trailing-rubbish-is-ignored`,
 	}
 
 	k, err := jwk.ParseKey([]byte(testECDSAPublicKey))

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package ar4si
+package ear
 
 import (
 	"fmt"
@@ -21,7 +21,7 @@ func Example_encode_minimalist() {
 	fmt.Println(string(j))
 
 	// Output:
-	// {"ear.status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
+	// {"ear.status":"affirming","eat_profile":"tag:github.com,2022:veraison/ear","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
 }
 
 func Example_encode_hefty() {
@@ -50,7 +50,7 @@ func Example_encode_hefty() {
 	fmt.Println(string(j))
 
 	// Output:
-	// {"ear.status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","ear.trustworthiness-vector":{"instance-identity":2,"configuration":2,"executables":3,"file-system":2,"hardware":2,"runtime-opaque":2,"storage-opaque":2,"sourced-data":2},"ear.raw-evidence":"3q2+7w==","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
+	// {"ear.status":"affirming","eat_profile":"tag:github.com,2022:veraison/ear","ear.trustworthiness-vector":{"instance-identity":2,"configuration":2,"executables":3,"file-system":2,"hardware":2,"runtime-opaque":2,"storage-opaque":2,"sourced-data":2},"ear.raw-evidence":"3q2+7w==","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
 }
 
 func Example_encode_veraison_extensions() {
@@ -61,7 +61,7 @@ func Example_encode_veraison_extensions() {
 	fmt.Println(string(j))
 
 	// Output:
-	// {"ear.status":"affirming","eat_profile":"tag:github.com/veraison/ar4si,2022-10-17","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","ear.veraison.processed-evidence":{"k1":"v1","k2":"v2"},"ear.veraison.verifier-added-claims":{"bar":"baz","foo":"bar"}}
+	// {"ear.status":"affirming","eat_profile":"tag:github.com,2022:veraison/ear","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","ear.veraison.processed-evidence":{"k1":"v1","k2":"v2"},"ear.veraison.verifier-added-claims":{"bar":"baz","foo":"bar"}}
 }
 
 func Example_decode_veraison_extensions() {
@@ -77,7 +77,7 @@ func Example_decode_veraison_extensions() {
 			"bar": "baz",
 			"foo": "bar"
 		},
-		"eat_profile": "tag:github.com/veraison/ar4si,2022-10-17"
+		"eat_profile": "tag:github.com,2022:veraison/ear"
 	}`
 	var ar AttestationResult
 	_ = ar.FromJSON([]byte(j))
@@ -103,7 +103,7 @@ func Example_colors() {
 			"executables": 32,
 			"hardware": 2
 		},
-		"eat_profile": "tag:github.com/veraison/ar4si,2022-10-17"
+		"eat_profile": "tag:github.com,2022:veraison/ear"
 	}`
 
 	var ar AttestationResult

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/veraison/ar4si
+module github.com/veraison/ear
 
 go 1.18
 

--- a/tclaim.go
+++ b/tclaim.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package ar4si
+package ear
 
 import "fmt"
 

--- a/tclaim_test.go
+++ b/tclaim_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package ar4si
+package ear
 
 import (
 	"testing"

--- a/trustvector.go
+++ b/trustvector.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package ar4si
+package ear
 
 // TrustVector is an implementation of the Trustworthiness Vector (and Claims)
 // described in §2.3 of draft-ietf-rats-ar4si-03, using a JSON serialization.

--- a/trustvector_test.go
+++ b/trustvector_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
-package ar4si
+package ear
 
 import (
 	"testing"


### PR DESCRIPTION
- This module now implements the EAT Attestation Result (ear) in
  addition to just what is defined by ar4si standard, so rename the
  module appropriately.
- Change EAT profile to be "tag:github.com,2022:veraison/ear", so that
  it adheres to the tag URI scheme. (Specifically, the first part after
  scheme should be an authority, not a URI with path.)