### PR TITLE
Usability features

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -14,7 +14,7 @@
 # 1. Change workflow name from "cover 100%" to "cover ≥92.5%". Script will automatically use 92.5%.
 # 2. Update README.md to use the new path to badge.svg because the path includes the workflow name.
 
-name: cover ≥90.0%
+name: cover ≥80.0%
 on: [push, pull_request]
 jobs:
   cover:

--- a/arc/cmd/create.go
+++ b/arc/cmd/create.go
@@ -51,7 +51,7 @@ the key in the default key file "skey.json", and save the result to "my-ear.jwt"
 				return fmt.Errorf("loading EAR claims-set from %q: %w", createClaims, err)
 			}
 
-			if err = ar.FromJSON(claimsSet); err != nil {
+			if err = ar.UnmarshalJSON(claimsSet); err != nil {
 				return fmt.Errorf("decoding EAR claims-set from %q: %w", createClaims, err)
 			}
 

--- a/arc/cmd/create_test.go
+++ b/arc/cmd/create_test.go
@@ -89,10 +89,10 @@ func Test_CreateCmd_skey_not_ok_for_signing(t *testing.T) {
 	}
 	cmd.SetArgs(args)
 
-	expectedErr := `signing EAR: failed to generate signature for signer #0 (alg=ES256): failed to sign payload: failed to retrieve ecdsa.PrivateKey out of *jwk.ecdsaPublicKey: failed to produce ecdsa.PrivateKey from *jwk.ecdsaPublicKey: argument to AssignIfCompatible() must be compatible with *ecdsa.PublicKey (was *ecdsa.PrivateKey)`
+	expectedErr := `failed to generate signature for signer #0 (alg=ES256): failed to sign payload: failed to retrieve ecdsa.PrivateKey out of *jwk.ecdsaPublicKey: failed to produce ecdsa.PrivateKey from *jwk.ecdsaPublicKey: argument to AssignIfCompatible() must be compatible with *ecdsa.PublicKey (was *ecdsa.PrivateKey)`
 
 	err := cmd.Execute()
-	assert.EqualError(t, err, expectedErr)
+	assert.ErrorContains(t, err, expectedErr)
 }
 
 func Test_CreateCmd_input_file_not_found(t *testing.T) {
@@ -131,7 +131,7 @@ func Test_CreateCmd_input_file_bad_format(t *testing.T) {
 	}
 	cmd.SetArgs(args)
 
-	expectedErr := `decoding EAR claims-set from "ear-claims.json": missing mandatory 'eat_profile', 'status', 'iat'`
+	expectedErr := `decoding EAR claims-set from "ear-claims.json": missing mandatory 'ear.status', 'eat_profile', 'iat'`
 
 	err := cmd.Execute()
 	assert.EqualError(t, err, expectedErr)
@@ -154,10 +154,10 @@ func Test_CreateCmd_unknown_signing_alg(t *testing.T) {
 	}
 	cmd.SetArgs(args)
 
-	expectedErr := `signing EAR: jws.Sign: expected algorithm to be of type jwa.SignatureAlgorithm but got ("XYZ", jwa.InvalidKeyAlgorithm)`
+	expectedErr := `expected algorithm to be of type jwa.SignatureAlgorithm but got ("XYZ", jwa.InvalidKeyAlgorithm)`
 
 	err := cmd.Execute()
-	assert.EqualError(t, err, expectedErr)
+	assert.ErrorContains(t, err, expectedErr)
 }
 
 func Test_CreateCmd_ok(t *testing.T) {

--- a/arc/cmd/verify.go
+++ b/arc/cmd/verify.go
@@ -69,7 +69,7 @@ embedded EAR claims-set and present a report of the trustworthiness vector.
 			fmt.Printf(">> %q signature successfully verified using %q\n", verifyInput, verifyPKey)
 
 			fmt.Println("[claims-set]")
-			if claimsSet, err = ar.ToJSONPretty(); err != nil {
+			if claimsSet, err = ar.MarshalJSONIndent("", "    "); err != nil {
 				return fmt.Errorf("unable to re-serialize the EAR claims-set: %w", err)
 			}
 			fmt.Println(string(claimsSet))

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@ Package ear implements an EAT attestation result format based on the
 information model defined in
 https://datatracker.ietf.org/doc/draft-ietf-rats-ar4si/
 
-Construction
+# Construction
 
 An AttestationResult object is constructed by populating the relevant fields.
 The mandatory attributes are: status, timestamp and profile.
@@ -40,7 +40,7 @@ and their meaning.)
 
 	ar.TrustVector := &tv
 
-Signing and Serializing
+# Signing and Serializing
 
 Once the AttestationResult is populated, it can be signed (i.e., wrapped in a
 JWT) by invoking the Sign method:
@@ -61,7 +61,7 @@ In this case, the returned buf contains a signed ES256 JWT with the JSON
 serialization of the AttestationResult object as its payload.  This is the usual
 JWT format that can be used as-is for interchange with other applications.
 
-Parsing and Verifying
+# Parsing and Verifying
 
 On the consumer end of the protocol, when the EAT containing the attestation
 result is received from a veraison verifier, the relying party needs to first
@@ -91,7 +91,7 @@ entity.
 		// handle troubles with appraisal
 	}
 
-Pretty printing
+# Pretty printing
 
 The package provides a Report method that allows pretty printing of the
 Trustworthiness Vector.  The caller can request a short summary or a detailed

--- a/ear.go
+++ b/ear.go
@@ -4,13 +4,17 @@
 package ear
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
-	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 // EatProfile is the EAT profile implemented by this package
@@ -40,7 +44,7 @@ const (
 )
 
 var (
-	StatusTierToString = map[TrustTier]string{
+	TrustTierToString = map[TrustTier]string{
 		TrustTierNone:            "none",
 		TrustTierAffirming:       "affirming",
 		TrustTierWarning:         "warning",
@@ -53,7 +57,157 @@ var (
 		"warning":         TrustTierWarning,
 		"contraindicated": TrustTierContraindicated,
 	}
+
+	IntToTrustTier = map[int]TrustTier{
+		0:  TrustTierNone,
+		2:  TrustTierAffirming,
+		32: TrustTierWarning,
+		96: TrustTierContraindicated,
+	}
 )
+
+// NewTrustTier returns a pointer to a newly-created TrustTier that has the
+// specified value. If the provided value is invalid for a TrustTier,
+// TrustTierNone will be used instead.
+// (This is essentially a Must- wrapper for ToTrustTier().)
+func NewTrustTier(v interface{}) *TrustTier {
+	tt, err := ToTrustTier(v)
+
+	if err != nil {
+		none := TrustTierNone
+		return &none
+	}
+
+	return tt
+}
+
+func getTrustTierFromInt(i int) (TrustTier, error) {
+	tier, ok := IntToTrustTier[i]
+	if !ok {
+		return TrustTierNone, fmt.Errorf("not a valid TrustTier value: %d", i)
+	}
+
+	return tier, nil
+}
+
+func getTrustTierFromString(s string) (TrustTier, error) {
+	tier, ok := StringToTrustTier[s]
+	if !ok {
+		i, err := strconv.Atoi(s)
+		if err == nil {
+			return getTrustTierFromInt(i)
+		}
+		return TrustTierNone, fmt.Errorf("not a valid TrustTier name: %q", s)
+	}
+
+	return tier, nil
+}
+
+func ToTrustTier(v interface{}) (*TrustTier, error) {
+	var (
+		err error
+		ok  bool
+
+		tier = TrustTierNone
+	)
+
+	switch t := v.(type) {
+	case string:
+		tier, err = getTrustTierFromString(t)
+	case []byte:
+		tier, err = getTrustTierFromString(string(t))
+	case TrustClaim:
+		tier = t.GetTier()
+	case int:
+		tier, err = getTrustTierFromInt(t)
+	case int8:
+		tier, err = getTrustTierFromInt(int(t))
+	case int16:
+		tier, err = getTrustTierFromInt(int(t))
+	case int32:
+		tier, err = getTrustTierFromInt(int(t))
+	case int64:
+		tier, err = getTrustTierFromInt(int(t))
+	case uint8:
+		tier, err = getTrustTierFromInt(int(t))
+	case uint16:
+		tier, err = getTrustTierFromInt(int(t))
+	case uint32:
+		tier, err = getTrustTierFromInt(int(t))
+	case uint:
+		if t > math.MaxInt64 {
+			err = fmt.Errorf("not a valid TrustTier value: %d", t)
+		} else {
+			tier, err = getTrustTierFromInt(int(t))
+		}
+	case uint64:
+		if t > math.MaxInt64 {
+			err = fmt.Errorf("not a valid TrustTier value: %d", t)
+
+		} else {
+			tier, err = getTrustTierFromInt(int(t))
+		}
+	case float64:
+		tier, ok = IntToTrustTier[int(t)]
+		if !ok {
+			err = fmt.Errorf("not a valid TrustTier value: %f (%d)", t, int(t))
+		}
+	case json.Number:
+		i, e := t.Int64()
+		if e != nil {
+			err = fmt.Errorf("not a valid TrustTier value: %v: %w", t, err)
+		} else {
+			tier, ok = IntToTrustTier[int(i)]
+			if !ok {
+				err = fmt.Errorf("not a valid TrustTier value: %v (%d)", t, int(i))
+			}
+		}
+	default:
+		err = fmt.Errorf("cannot convert %v (type %T) to TrustTier", t, t)
+	}
+
+	return &tier, err
+}
+
+func (o TrustTier) Format(color bool) string {
+	if color {
+		return o.ColorString()
+	}
+
+	return o.String()
+}
+
+func (o TrustTier) String() string {
+	return TrustTierToString[o]
+}
+
+func (o TrustTier) ColorString() string {
+	const (
+		reset  = `\033[0m`
+		red    = `\033[41m`
+		yellow = `\033[43m`
+		green  = `\033[42m`
+		white  = `\033[47m`
+
+		unexpected = `\033[1;33;41m`
+	)
+
+	var color string
+	switch o {
+	case TrustTierNone:
+		color = white
+	case TrustTierAffirming:
+		color = green
+	case TrustTierWarning:
+		color = yellow
+	case TrustTierContraindicated:
+		color = red
+	default:
+		color = unexpected
+	}
+
+	return color + o.String() + reset
+}
 
 func (o TrustTier) MarshalJSON() ([]byte, error) {
 	var (
@@ -61,7 +215,7 @@ func (o TrustTier) MarshalJSON() ([]byte, error) {
 		ok bool
 	)
 
-	s, ok = StatusTierToString[o]
+	s, ok = TrustTierToString[o]
 	if !ok {
 		return nil, fmt.Errorf("unknown trust tier '%d'", o)
 	}
@@ -102,33 +256,111 @@ type AttestationResult struct {
 	Extensions
 }
 
-// ToJSON validates and serializes to JSON an AttestationResult object
-func (o AttestationResult) ToJSON() ([]byte, error) {
+// NewAttestationResult returns a pointer to a new fully-initialized
+// AttestationResult.
+func NewAttestationResult() *AttestationResult {
+	status := TrustTierNone
+	iat := time.Now().Unix()
+	profile := EatProfile
+
+	return &AttestationResult{
+		Status:      &status,
+		Profile:     &profile,
+		TrustVector: &TrustVector{},
+		IssuedAt:    &iat,
+	}
+}
+
+// MarshalJSON validates and serializes to JSON an AttestationResult object
+func (o AttestationResult) MarshalJSON() ([]byte, error) {
 	if err := o.validate(); err != nil {
 		return nil, err
 	}
 
-	return json.Marshal(o)
+	return json.Marshal(o.AsMap())
 }
 
-// ToJSONPretty does the same as ToJSON but add NL and indentation to improve
-// readability
-func (o AttestationResult) ToJSONPretty() ([]byte, error) {
+// MarshalJSONIndent is like MarshalJSON but applies Indent to format the
+// output. Each JSON element in the output will begin on a new line beginning
+// with prefix followed by one or more copies of indent according to the
+// indentation nesting.
+func (o AttestationResult) MarshalJSONIndent(prefix, indent string) ([]byte, error) {
 	if err := o.validate(); err != nil {
 		return nil, err
 	}
 
-	return json.MarshalIndent(o, "", "  ")
+	return json.MarshalIndent(o.AsMap(), prefix, indent)
 }
 
-// FromJSON de-serializes an AttestationResult object from its JSON
+// UnmarshalJSON de-serializes an AttestationResult object from its JSON
 // representation and validates it.
-func (o *AttestationResult) FromJSON(data []byte) error {
-	err := json.Unmarshal(data, o)
-	if err == nil {
-		return o.validate()
+func (o *AttestationResult) UnmarshalJSON(data []byte) error {
+	var oMap map[string]interface{}
+	if err := json.Unmarshal(data, &oMap); err != nil {
+		return err
 	}
-	return err
+
+	if err := o.populateFromMap(oMap); err != nil {
+		return err
+	}
+
+	return o.validate()
+}
+
+// AsMap returns a map[string]interface{} with EAR claim names mapped onto
+// corresponding values.
+func (o AttestationResult) AsMap() map[string]interface{} {
+	oMap := make(map[string]interface{})
+
+	if o.Status != nil {
+		oMap["ear.status"] = *o.Status
+	}
+
+	if o.Profile != nil {
+		oMap["eat_profile"] = *o.Profile
+	}
+
+	if o.IssuedAt != nil {
+		oMap["iat"] = *o.IssuedAt
+	}
+
+	if o.TrustVector != nil {
+		oMap["ear.trustworthiness-vector"] = o.TrustVector.AsMap()
+	}
+
+	if o.RawEvidence != nil {
+		oMap["ear.raw-evidence"] = *o.RawEvidence
+	}
+
+	if o.AppraisalPolicyID != nil {
+		oMap["ear.appraisal-policy-id"] = *o.AppraisalPolicyID
+	}
+
+	if o.VeraisonProcessedEvidence != nil {
+		oMap["ear.veraison.processed-evidence"] = *o.VeraisonProcessedEvidence
+	}
+
+	if o.VeraisonVerifierAddedClaims != nil {
+		oMap["ear.veraison.verifier-added-claims"] = *o.VeraisonVerifierAddedClaims
+	}
+
+	return oMap
+}
+
+// UpdateStatusFromTrustVector  ensure that Status trustworthiness is not
+// higher than is warranted by trust vector claims. For every claim that has
+// been made (i.e. is not in TrustTierNone), if the claim's trust tier is lower
+// than that of the Status, adjust the status to the claim's tier. This means
+// that the overall result will not assert to be more trustworthy than
+// individual vector claims (though it could be less trustworthy if had been
+// manually set that way).
+func (o *AttestationResult) UpdateStatusFromTrustVector() {
+	for _, claimValue := range o.TrustVector.AsMap() {
+		claimTier := claimValue.GetTier()
+		if *o.Status < claimTier {
+			*o.Status = claimTier
+		}
+	}
 }
 
 func (o AttestationResult) validate() error {
@@ -175,24 +407,15 @@ type Extensions struct {
 // AttestationResult object is populated with the decoded claims (possibly
 // including the Trustworthiness vector).
 func (o *AttestationResult) Verify(data []byte, alg jwa.KeyAlgorithm, key interface{}) error {
-	buf, err := jws.Verify(data, jws.WithKey(alg, key))
+	token, err := jwt.Parse(data, jwt.WithKey(alg, key))
 	if err != nil {
 		return fmt.Errorf("failed verifying JWT message: %w", err)
 	}
 
-	// TODO(tho) add any JWT specific checks on top of the base JWS verification
-	// See https://github.com/veraison/ear/issues/6
+	claims := token.PrivateClaims()
+	claims["iat"] = token.IssuedAt().Unix()
 
-	var ar AttestationResult
-
-	err = ar.FromJSON(buf)
-	if err != nil {
-		return fmt.Errorf("failed parsing JWT payload: %w", err)
-	}
-
-	*o = ar
-
-	return nil
+	return o.populateFromMap(claims)
 }
 
 // Sign validates the AttestationResult object, encodes it to JSON and wraps it
@@ -200,10 +423,150 @@ func (o *AttestationResult) Verify(data []byte, alg jwa.KeyAlgorithm, key interf
 // compatible with the requested signing algorithm.  On success, the complete
 // JWT token is returned.
 func (o AttestationResult) Sign(alg jwa.KeyAlgorithm, key interface{}) ([]byte, error) {
-	payload, err := o.ToJSON()
-	if err != nil {
+	if err := o.validate(); err != nil {
 		return nil, err
 	}
 
-	return jws.Sign(payload, jws.WithKey(alg, key))
+	token := jwt.New()
+	for k, v := range o.AsMap() {
+		if err := token.Set(k, v); err != nil {
+			return nil, fmt.Errorf("setting %s: %w", k, err)
+		}
+	}
+
+	return jwt.Sign(token, jwt.WithKey(alg, key))
+}
+
+func (o *AttestationResult) populateFromMap(m map[string]interface{}) error {
+	var err error
+
+	var missing, invalid []string
+
+	expected := []string{
+		"ear.status",
+		"eat_profile",
+		"iat",
+		"ear.trustworthiness-vector",
+		"ear.raw-evidence",
+		"ear.appraisal-policy-id",
+		"ear.veraison.processed-evidence",
+		"ear.veraison.verifier-added-claims",
+	}
+	extra := getExtraKeys(m, expected)
+
+	v, ok := m["ear.status"]
+	if ok {
+		o.Status, err = ToTrustTier(v)
+		if err != nil {
+			invalid = append(invalid, "'ear.status'")
+		}
+	} else {
+		missing = append(missing, "'ear.status'")
+	}
+
+	v, ok = m["eat_profile"]
+	if ok {
+		profile, okay := v.(string)
+		if !okay {
+			invalid = append(invalid, "'eat_profiles'")
+		}
+		o.Profile = &profile
+
+	} else {
+		missing = append(missing, "'eat_profile'")
+	}
+
+	v, ok = m["iat"]
+	if ok {
+		var iat int64
+		switch t := v.(type) {
+		case float64:
+			iat = int64(t)
+		case int:
+			iat = int64(t)
+		case int64:
+			iat = t
+		default:
+			invalid = append(invalid, "'iat'")
+		}
+		o.IssuedAt = &iat
+	} else {
+		missing = append(missing, "'iat'")
+	}
+
+	v, ok = m["ear.trustworthiness-vector"]
+	if ok {
+		o.TrustVector, err = ToTrustVector(v)
+		if err != nil {
+			invalid = append(invalid, fmt.Sprintf("'ear.trustworthiness-vector' (%s)", err))
+		}
+	}
+
+	var stringVal string
+
+	v, ok = m["ear.raw-evidence"]
+	if ok {
+		rawEvString, okay := v.(string)
+		if !okay {
+			invalid = append(invalid, "'ear.raw-evidence'")
+		}
+
+		decodedRawEv, err := base64.StdEncoding.DecodeString(rawEvString)
+		if err != nil {
+			invalid = append(invalid, "'ear.raw-evidence'")
+		}
+
+		o.RawEvidence = &decodedRawEv
+	}
+
+	v, ok = m["ear.appraisal-policy-id"]
+	if ok {
+		stringVal, ok = v.(string)
+		if !ok {
+			invalid = append(invalid, "'ear.appraisal-policy-id'")
+		}
+		o.AppraisalPolicyID = &stringVal
+	}
+
+	v, ok = m["ear.veraison.processed-evidence"]
+	if ok {
+		processedEvidence, okay := v.(map[string]interface{})
+		if !okay {
+			invalid = append(invalid, "'ear.veraison.processed-evidence'")
+		}
+		o.VeraisonProcessedEvidence = &processedEvidence
+	}
+
+	v, ok = m["ear.veraison.verifier-added-claims"]
+	if ok {
+		addedClaims, okay := v.(map[string]interface{})
+		if !okay {
+			invalid = append(invalid, "'ear.veraison.verifier-added-claims'")
+		}
+		o.VeraisonVerifierAddedClaims = &addedClaims
+
+	}
+
+	var problems []string
+
+	if len(missing) > 0 {
+		msg := fmt.Sprintf("missing mandatory %s", strings.Join(missing, ", "))
+		problems = append(problems, msg)
+	}
+
+	if len(invalid) > 0 {
+		msg := fmt.Sprintf("invalid values(s) for  %s", strings.Join(invalid, ", "))
+		problems = append(problems, msg)
+	}
+
+	if len(extra) > 0 {
+		msg := fmt.Sprintf("unexpected %s", strings.Join(extra, ", "))
+		problems = append(problems, msg)
+	}
+
+	if len(problems) > 0 {
+		return errors.New(strings.Join(problems, "; "))
+	}
+
+	return nil
 }

--- a/example_test.go
+++ b/example_test.go
@@ -16,12 +16,12 @@ func Example_encode_minimalist() {
 		Profile:           &testProfile,
 	}
 
-	j, _ := ar.ToJSON()
+	j, _ := ar.MarshalJSON()
 
 	fmt.Println(string(j))
 
 	// Output:
-	// {"ear.status":"affirming","eat_profile":"tag:github.com,2022:veraison/ear","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
+	// {"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","ear.status":"affirming","eat_profile":"tag:github.com,2022:veraison/ear","iat":1666091373}
 }
 
 func Example_encode_hefty() {
@@ -45,23 +45,23 @@ func Example_encode_hefty() {
 		Profile:           &testProfile,
 	}
 
-	j, _ := ar.ToJSON()
+	j, _ := ar.MarshalJSON()
 
 	fmt.Println(string(j))
 
 	// Output:
-	// {"ear.status":"affirming","eat_profile":"tag:github.com,2022:veraison/ear","ear.trustworthiness-vector":{"instance-identity":2,"configuration":2,"executables":3,"file-system":2,"hardware":2,"runtime-opaque":2,"storage-opaque":2,"sourced-data":2},"ear.raw-evidence":"3q2+7w==","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d"}
+	// {"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","ear.raw-evidence":"3q2+7w==","ear.status":"affirming","ear.trustworthiness-vector":{"configuration":2,"executables":3,"file-system":2,"hardware":2,"instance-identity":2,"runtime-opaque":2,"sourced-data":2,"storage-opaque":2},"eat_profile":"tag:github.com,2022:veraison/ear","iat":1666091373}
 }
 
 func Example_encode_veraison_extensions() {
 	ar := testAttestationResultsWithVeraisonExtns
 
-	j, _ := ar.ToJSON()
+	j, _ := ar.MarshalJSON()
 
 	fmt.Println(string(j))
 
 	// Output:
-	// {"ear.status":"affirming","eat_profile":"tag:github.com,2022:veraison/ear","iat":1666091373,"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","ear.veraison.processed-evidence":{"k1":"v1","k2":"v2"},"ear.veraison.verifier-added-claims":{"bar":"baz","foo":"bar"}}
+	// {"ear.appraisal-policy-id":"https://veraison.example/policy/1/60a0068d","ear.status":"affirming","ear.veraison.processed-evidence":{"k1":"v1","k2":"v2"},"ear.veraison.verifier-added-claims":{"bar":"baz","foo":"bar"},"eat_profile":"tag:github.com,2022:veraison/ear","iat":1666091373}
 }
 
 func Example_decode_veraison_extensions() {
@@ -80,9 +80,9 @@ func Example_decode_veraison_extensions() {
 		"eat_profile": "tag:github.com,2022:veraison/ear"
 	}`
 	var ar AttestationResult
-	_ = ar.FromJSON([]byte(j))
+	_ = ar.UnmarshalJSON([]byte(j))
 
-	fmt.Println(StatusTierToString[*ar.Status])
+	fmt.Println(TrustTierToString[*ar.Status])
 	fmt.Println((*ar.VeraisonProcessedEvidence)["k1"])
 	fmt.Println((*ar.VeraisonVerifierAddedClaims)["bar"])
 
@@ -107,7 +107,7 @@ func Example_colors() {
 	}`
 
 	var ar AttestationResult
-	_ = ar.FromJSON([]byte(j))
+	_ = ar.UnmarshalJSON([]byte(j))
 
 	short, color := true, true
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/veraison/ear
 go 1.18
 
 require (
+	github.com/huandu/xstrings v1.3.3
 	github.com/lestrrat-go/jwx/v2 v2.0.6
 	github.com/spf13/afero v1.9.2
 	github.com/spf13/cobra v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/huandu/xstrings v1.3.3 h1:/Gcsuc1x8JVbJ9/rlye4xZnVAbEkGauT8lbebqcQws4=
+github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=

--- a/trustclaim.go
+++ b/trustclaim.go
@@ -6,13 +6,13 @@ package ear
 import "fmt"
 
 // trustworthiness claim
-type TClaim int8
+type TrustClaim int8
 
 type details struct {
 	short, long string
 }
 
-type detailsMap map[TClaim]details
+type detailsMap map[TrustClaim]details
 
 var (
 	noneDetails = detailsMap{
@@ -229,7 +229,7 @@ var (
 )
 
 // TrustTier provides the trust tier bucket of the trustworthiness claim
-func (o TClaim) TrustTier(color bool) string {
+func (o TrustClaim) TrustTier(color bool) string {
 	const (
 		rst    = `\033[0m`
 		red    = `\033[41m`
@@ -268,31 +268,31 @@ func (o TClaim) TrustTier(color bool) string {
 	return s
 }
 
-func (o TClaim) trustTierTag(color bool) string {
+func (o TrustClaim) trustTierTag(color bool) string {
 	return "[" + o.TrustTier(color) + "]"
 }
 
-func (o TClaim) IsNone() bool {
+func (o TrustClaim) IsNone() bool {
 	// none = [-1, 1]
 	return o >= -1 && o <= 1
 }
 
-func (o TClaim) IsAffirming() bool {
+func (o TrustClaim) IsAffirming() bool {
 	// affirming = [-32, -2] U [2, 31]
 	return (o >= -32 && o <= -2) || (o >= 2 && o <= 31)
 }
 
-func (o TClaim) IsWarning() bool {
+func (o TrustClaim) IsWarning() bool {
 	// warning = [-96, -33] U [32, 95]
 	return (o >= -96 && o <= -33) || (o >= 32 && o <= 95)
 }
 
-func (o TClaim) IsContraindicated() bool {
+func (o TrustClaim) IsContraindicated() bool {
 	// contraindicated = [-128, -97] U [96, 127]
 	return (o >= -128 && o <= -97) || (o >= 96 && o <= 127)
 }
 
-func (o TClaim) detailsPrinter(dm detailsMap, short bool, color bool) string {
+func (o TrustClaim) detailsPrinter(dm detailsMap, short bool, color bool) string {
 	// "none" statuses have shared semantics
 	if o.IsNone() {
 		return noneToString(o, short, color)
@@ -312,39 +312,39 @@ func (o TClaim) detailsPrinter(dm detailsMap, short bool, color bool) string {
 	return s.long
 }
 
-func (o TClaim) asInstanceIdentityDetails(short, color bool) string {
+func (o TrustClaim) asInstanceIdentityDetails(short, color bool) string {
 	return o.detailsPrinter(instanceIdentityDetails, short, color)
 }
 
-func (o TClaim) asConfigurationDetails(short, color bool) string {
+func (o TrustClaim) asConfigurationDetails(short, color bool) string {
 	return o.detailsPrinter(configurationDetails, short, color)
 }
 
-func (o TClaim) asExecutablesDetails(short, color bool) string {
+func (o TrustClaim) asExecutablesDetails(short, color bool) string {
 	return o.detailsPrinter(executablesDetails, short, color)
 }
 
-func (o TClaim) asFileSystemDetails(short, color bool) string {
+func (o TrustClaim) asFileSystemDetails(short, color bool) string {
 	return o.detailsPrinter(fileSystemDetails, short, color)
 }
 
-func (o TClaim) asHardwareDetails(short, color bool) string {
+func (o TrustClaim) asHardwareDetails(short, color bool) string {
 	return o.detailsPrinter(hardwareDetails, short, color)
 }
 
-func (o TClaim) asRuntimeOpaqueDetails(short, color bool) string {
+func (o TrustClaim) asRuntimeOpaqueDetails(short, color bool) string {
 	return o.detailsPrinter(runtimeOpaqueDetails, short, color)
 }
 
-func (o TClaim) asStorageOpaqueDetails(short, color bool) string {
+func (o TrustClaim) asStorageOpaqueDetails(short, color bool) string {
 	return o.detailsPrinter(storageOpaqueDetails, short, color)
 }
 
-func (o TClaim) asSourcedDataDetails(short, color bool) string {
+func (o TrustClaim) asSourcedDataDetails(short, color bool) string {
 	return o.detailsPrinter(sourcedDataDetails, short, color)
 }
 
-func noneToString(tc TClaim, short, color bool) string {
+func noneToString(tc TrustClaim, short, color bool) string {
 	s, ok := noneDetails[tc]
 	if ok {
 		if short {

--- a/trustclaim.go
+++ b/trustclaim.go
@@ -14,12 +14,68 @@ type details struct {
 
 type detailsMap map[TrustClaim]details
 
+const (
+	// See details definitions below for detailed claim value interpretations.
+
+	// general
+	VerifierMalfunctionClaim    = TrustClaim(-1)
+	NoClaim                     = TrustClaim(0)
+	UnexpectedEvidenceClaim     = TrustClaim(1)
+	AffirmingClaim              = TrustClaim(2)
+	CryptoValidationFailedClaim = TrustClaim(99)
+
+	// instance identity
+	TrustworthyInstanceClaim       = TrustClaim(2)
+	InstanceIdentityAffirmingClaim = TrustClaim(2)
+	UntrustworthyInstanceClaim     = TrustClaim(96)
+	UnrecognizedInstanceClaim      = TrustClaim(97)
+
+	// config
+	ApprovedConfigClaim      = TrustClaim(2)
+	NoConfigVulnsClaim       = TrustClaim(3)
+	UnsafeConfigClaim        = TrustClaim(32)
+	UnsupportableConfigClaim = TrustClaim(96)
+
+	// exectuabes & runtime
+	ApprovedRuntimeClaim     = TrustClaim(2)
+	ApprovedBootClaim        = TrustClaim(3)
+	UnsafeRuntime            = TrustClaim(32)
+	UnrecognizedRuntimeClaim = TrustClaim(33)
+	ContraindicatedRuntime   = TrustClaim(96)
+
+	// file system
+	ApprovedFilesClaim        = TrustClaim(2)
+	UnrecognizedFilesClaim    = TrustClaim(32)
+	ContraindicatedFilesClaim = TrustClaim(96)
+
+	// hardware
+	GenuineHardwareClaim         = TrustClaim(2)
+	UnsafeHardwareClaim          = TrustClaim(32)
+	ContraindicatedHardwareClaim = TrustClaim(96)
+	UnrecognizedHardwareClaim    = TrustClaim(97)
+
+	// opaque runtime
+	EncryptedMemoryRuntimeClaim = TrustClaim(2)
+	IsolatedMemoryRuntimeClaim  = TrustClaim(32)
+	VisibleMemoryRuntimeClaim   = TrustClaim(96)
+
+	// opaque storage
+	HwKeysEncryptedSecretsClaim = TrustClaim(2)
+	SwKeysEncryptedSecretsClaim = TrustClaim(32)
+	UnencryptedSecretsClaim     = TrustClaim(96)
+
+	// sourced data
+	TrustedSourcesClaim         = TrustClaim(2)
+	UntrustedSourcesClaim       = TrustClaim(3)
+	ContraindicatedSourcesClaim = TrustClaim(96)
+)
+
 var (
 	noneDetails = detailsMap{
 		// Value -1: A verifier malfunction occurred during the Verifier's
 		// appraisal processing.
 		// NOTE: similar to HTTP 5xx (server error)
-		-1: {
+		VerifierMalfunctionClaim: {
 			short: "verifier malfunction",
 			long:  "A verifier malfunction occurred during the Verifier's appraisal processing.",
 		},
@@ -30,7 +86,7 @@ var (
 		// Trustworthiness Claim with enumeration '0', and no Trustworthiness
 		// Claim being provided.
 		// NOTE: not sure why this is grouped with -1 and 1.
-		0: {
+		NoClaim: {
 			short: "no claim being made",
 			long:  "The Evidence received is insufficient to make a conclusion.",
 		},
@@ -38,7 +94,7 @@ var (
 		// Verifier is unable to parse. An example might be that the wrong type
 		// of Evidence has been delivered.
 		// NOTE: similar to HTTP 4xx (client error)
-		1: {
+		UnexpectedEvidenceClaim: {
 			short: "unexpected evidence",
 			long:  "The Evidence received contains unexpected elements which the Verifier is unable to parse.",
 		},
@@ -49,19 +105,19 @@ var (
 	// should only be generated if the Verifier actually expects to recognize
 	// the unique identity of the Attester.)
 	instanceIdentityDetails = detailsMap{
-		2: {
+		TrustworthyInstanceClaim: {
 			short: "recognized and not compromised",
 			long:  "The Attesting Environment is recognized, and the associated instance of the Attester is not known to be compromised.",
 		},
-		96: {
+		UntrustworthyInstanceClaim: {
 			short: "recognized but not trustworthy",
 			long:  "The Attesting Environment is recognized, but its unique private key indicates a device which is not trustworthy.",
 		},
-		97: {
+		UnrecognizedInstanceClaim: {
 			short: "not recognized",
 			long:  "The Attesting Environment is not recognized; however the Verifier believes it should be.",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},
@@ -69,23 +125,23 @@ var (
 	// A Verifier has appraised an Attester's configuration, and is able to make
 	// conclusions regarding the exposure of known vulnerabilities.
 	configurationDetails = detailsMap{
-		2: {
+		ApprovedConfigClaim: {
 			short: "all recognized and approved",
 			long:  "The configuration is a known and approved config.",
 		},
-		3: {
+		NoConfigVulnsClaim: {
 			short: "no known vulnerabilities",
 			long:  "The configuration includes or exposes no known vulnerabilities",
 		},
-		32: {
+		UnsafeConfigClaim: {
 			short: "known vulnerabilities",
 			long:  "The configuration includes or exposes known vulnerabilities.",
 		},
-		96: {
+		UnsupportableConfigClaim: {
 			short: "unacceptable security vulnerabilities",
 			long:  "The configuration is unsupportable as it exposes unacceptable security vulnerabilities",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},
@@ -94,27 +150,27 @@ var (
 	// and/or other objects which have been loaded into the Target environment's
 	// memory.
 	executablesDetails = detailsMap{
-		2: {
+		ApprovedRuntimeClaim: {
 			short: "recognized and approved boot- and run-time",
 			long:  "Only a recognized genuine set of approved executables, scripts, files, and/or objects have been loaded during and after the boot process.",
 		},
-		3: {
+		ApprovedBootClaim: {
 			short: "recognized and approved boot-time",
 			long:  "Only a recognized genuine set of approved executables have been loaded during the boot process.",
 		},
-		32: {
+		UnsafeRuntime: {
 			short: "recognized but known bugs or vulnerabilities",
 			long:  "Only a recognized genuine set of executables, scripts, files, and/or objects have been loaded. However the Verifier cannot vouch for a subset of these due to known bugs or other known vulnerabilities.",
 		},
-		33: {
+		UnrecognizedRuntimeClaim: {
 			short: "unrecognized run-time",
 			long:  "Runtime memory includes executables, scripts, files, and/or objects which are not recognized.",
 		},
-		96: {
+		ContraindicatedRuntime: {
 			short: "contraindicated run-time",
 			long:  "Runtime memory includes executables, scripts, files, and/or object which are contraindicated.",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},
@@ -124,19 +180,19 @@ var (
 	// these directory and expected files are via an unspecified management
 	// interface.)
 	fileSystemDetails = detailsMap{
-		2: {
+		ApprovedFilesClaim: {
 			short: "all recognized and approved",
 			long:  "Only a recognized set of approved files are found.",
 		},
-		32: {
+		UnrecognizedFilesClaim: {
 			short: "unrecognized item(s) found",
 			long:  "The file system includes unrecognized executables, scripts, or files.",
 		},
-		96: {
+		ContraindicatedFilesClaim: {
 			short: "contraindicated item(s) found",
 			long:  "The file system includes contraindicated executables, scripts, or files.",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},
@@ -144,23 +200,23 @@ var (
 	// A Verifier has appraised any Attester hardware and firmware which are
 	// able to expose fingerprints of their identity and running code.
 	hardwareDetails = detailsMap{
-		2: {
+		GenuineHardwareClaim: {
 			short: "genuine",
 			long:  "An Attester has passed its hardware and/or firmware verifications needed to demonstrate that these are genuine/supported.",
 		},
-		32: {
+		UnsafeHardwareClaim: {
 			short: "genuine but known bugs or vulnerabilities",
 			long:  "An Attester contains only genuine/supported hardware and/or firmware, but there are known security vulnerabilities.",
 		},
-		96: {
+		ContraindicatedHardwareClaim: {
 			short: "genuine but contraindicated",
 			long:  "Attester hardware and/or firmware is recognized, but its trustworthiness is contraindicated.",
 		},
-		97: {
+		UnrecognizedHardwareClaim: {
 			short: "unrecognized",
 			long:  "A Verifier does not recognize an Attester's hardware or firmware, but it should be recognized.",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},
@@ -168,20 +224,20 @@ var (
 	// A Verifier has appraised the visibility of Attester objects in memory
 	// from perspectives outside the Attester.
 	runtimeOpaqueDetails = detailsMap{
-		2: {
+		EncryptedMemoryRuntimeClaim: {
 			short: "memory encryption",
 			long:  "the Attester's executing Target Environment and Attesting Environments are encrypted and within Trusted Execution Environment(s) opaque to the operating system, virtual machine manager, and peer applications.",
 		},
-		32: {
+		IsolatedMemoryRuntimeClaim: {
 			// TODO(tho) not sure about the shorthand
 			short: "memory isolation",
 			long:  "the Attester's executing Target Environment and Attesting Environments are inaccessible from any other parallel application or Guest VM running on the Attester's physical device.",
 		},
-		96: {
+		VisibleMemoryRuntimeClaim: {
 			short: "visible",
 			long:  "The Verifier has concluded that in memory objects are unacceptably visible within the physical host that supports the Attester.",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},
@@ -189,19 +245,19 @@ var (
 	// A Verifier has appraised that an Attester is capable of encrypting
 	// persistent storage.
 	storageOpaqueDetails = detailsMap{
-		2: {
+		HwKeysEncryptedSecretsClaim: {
 			short: "encrypted secrets with HW-backed keys",
 			long:  "the Attester encrypts all secrets in persistent storage via using keys which are never visible outside an HSM or the Trusted Execution Environment hardware.",
 		},
-		32: {
+		SwKeysEncryptedSecretsClaim: {
 			short: "encrypted secrets with non HW-backed keys",
 			long:  "the Attester encrypts all persistently stored secrets, but without using hardware backed keys.",
 		},
-		96: {
+		UnencryptedSecretsClaim: {
 			short: "unencrypted secrets",
 			long:  "There are persistent secrets which are stored unencrypted in an Attester.",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},
@@ -209,19 +265,19 @@ var (
 	// A Verifier has evaluated the integrity of data objects from external
 	// systems used by the Attester.
 	sourcedDataDetails = detailsMap{
-		2: {
+		TrustedSourcesClaim: {
 			short: "from attesters in the affirming tier",
 			long:  `All essential Attester source data objects have been provided by other Attester(s) whose most recent appraisal(s) had both no Trustworthiness Claims of "0" where the current Trustworthiness Claim is "Affirming", as well as no "Warning" or "Contraindicated" Trustworthiness Claims.`,
 		},
-		32: {
+		UntrustedSourcesClaim: {
 			short: "from unattested sources or attesters in the warning tier",
 			long:  `Attester source data objects come from unattested sources, or attested sources with "Warning" type Trustworthiness Claims`,
 		},
-		96: {
+		ContraindicatedSourcesClaim: {
 			short: "from attesters in the contraindicated tier",
 			long:  "Attester source data objects come from contraindicated sources.",
 		},
-		99: {
+		CryptoValidationFailedClaim: {
 			short: "cryptographic validation failed",
 			long:  "Cryptographic validation of the Evidence has failed.",
 		},

--- a/trustclaim_test.go
+++ b/trustclaim_test.go
@@ -49,11 +49,11 @@ var (
 	}
 )
 
-func TestTClaim_TrustTier_entire_range(t *testing.T) {
+func TestTrustClaim_TrustTier_entire_range(t *testing.T) {
 	for s, a := range ranges {
 		for _, i := range a {
 			color := false
-			assert.Equal(t, s, TClaim(i).TrustTier(color), "enum: %d", i)
+			assert.Equal(t, s, TrustClaim(i).TrustTier(color), "enum: %d", i)
 		}
 	}
 }

--- a/trustvector.go
+++ b/trustvector.go
@@ -6,14 +6,14 @@ package ear
 // TrustVector is an implementation of the Trustworthiness Vector (and Claims)
 // described in §2.3 of draft-ietf-rats-ar4si-03, using a JSON serialization.
 type TrustVector struct {
-	InstanceIdentity TClaim `json:"instance-identity"`
-	Configuration    TClaim `json:"configuration"`
-	Executables      TClaim `json:"executables"`
-	FileSystem       TClaim `json:"file-system"`
-	Hardware         TClaim `json:"hardware"`
-	RuntimeOpaque    TClaim `json:"runtime-opaque"`
-	StorageOpaque    TClaim `json:"storage-opaque"`
-	SourcedData      TClaim `json:"sourced-data"`
+	InstanceIdentity TrustClaim `json:"instance-identity"`
+	Configuration    TrustClaim `json:"configuration"`
+	Executables      TrustClaim `json:"executables"`
+	FileSystem       TrustClaim `json:"file-system"`
+	Hardware         TrustClaim `json:"hardware"`
+	RuntimeOpaque    TrustClaim `json:"runtime-opaque"`
+	StorageOpaque    TrustClaim `json:"storage-opaque"`
+	SourcedData      TrustClaim `json:"sourced-data"`
 }
 
 // Report provides an annotated view of the TrustVector state.

--- a/util.go
+++ b/util.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package ear
+
+func getExtraKeys(m map[string]interface{}, expected []string) []string {
+	expectedMap := make(map[string]bool, len(expected))
+	for _, e := range expected {
+		expectedMap[e] = true
+	}
+
+	var extra []string
+
+	for k := range m {
+		if _, found := expectedMap[k]; !found {
+			extra = append(extra, k)
+		}
+	}
+
+	return extra
+}

--- a/util_test.go
+++ b/util_test.go
@@ -1,0 +1,36 @@
+// Copyright 2022 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package ear
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getExtraKeys(t *testing.T) {
+	m := map[string]interface{}{
+		"name":   "String Archer",
+		"alias":  "duchess",
+		"age":    42,
+		"height": "6'2\"",
+		"eyes":   "blue",
+		"hair":   "black",
+	}
+
+	extras := getExtraKeys(m, []string{"name", "age", "height"})
+	assert.ElementsMatch(t, []string{"alias", "eyes", "hair"}, extras)
+
+	extras = getExtraKeys(m, []string{"name", "alias", "age", "height", "eyes", "hair"})
+	assert.ElementsMatch(t, []string{}, extras)
+
+	extras = getExtraKeys(m, []string{"name", "age", "family", "language"})
+	assert.ElementsMatch(t, []string{"alias", "height", "eyes", "hair"}, extras)
+
+	extras = getExtraKeys(m, []string{})
+	assert.ElementsMatch(t, []string{"name", "alias", "age", "height", "eyes", "hair"}, extras)
+
+	extras = getExtraKeys(map[string]interface{}{}, []string{})
+	assert.ElementsMatch(t, []string{}, extras)
+}


### PR DESCRIPTION
Implement a number of changes and additions to aid in usability of this
library. No material changes are being made toe the forts of EAR or
AR4SI as part of this.

- Rename To/FromJSON to Marshal/UnmarshaJSON to be consistent with
  common golang conventions. Rename ToJSONPretty to MarshalJSONIndent
  for the same reason.
- Add AsMap() methods to TrustVector and AttestationResult that converts
  these structs to map[string]interface{}.
- Add UpdateStatusFromTrustVector() to AttestationResult, that brings
  Status into alignment with TrustVector values (unless it was
  explicitly set to a lower trust value).
- Add ToTrustTier and ToTrustClaim to convert arbitrary interfaces to
  corresponding structs.
- Add TrustClaim.GetTier() that returns the tier corresponding to the
  claim value.
- Add NewAttestationResult that returns a fully initialized attestation
  result.
- Switch to using `jwt` package for signing.