### PR TITLE
Ensure NewAttestationResult() returns a valid result

### DIFF
--- a/ear.go
+++ b/ear.go
@@ -42,7 +42,11 @@ func (o B64Url) MarshalJSON() ([]byte, error) {
 
 // NewAttestationResult returns a pointer to a new fully-initialized
 // AttestationResult.
-func NewAttestationResult(submodName string) *AttestationResult {
+func NewAttestationResult(
+	submodName string,
+	verifierBuild string,
+	verifierDeveloper string,
+) *AttestationResult {
 	status := TrustTierNone
 	iat := time.Now().Unix()
 	profile := EatProfile
@@ -55,6 +59,10 @@ func NewAttestationResult(submodName string) *AttestationResult {
 				TrustVector: &TrustVector{},
 				Status:      &status,
 			},
+		},
+		VerifierID: &VerifierIdentity{
+			Build:     &verifierBuild,
+			Developer: &verifierDeveloper,
 		},
 	}
 }

--- a/ear_test.go
+++ b/ear_test.go
@@ -272,7 +272,7 @@ func TestRoundTrip_tampering(t *testing.T) {
 }
 
 func TestUpdateStatusFromTrustVector(t *testing.T) {
-	ar := NewAttestationResult("test")
+	ar := NewAttestationResult("test", "test", "test")
 
 	ar.UpdateStatusFromTrustVector()
 	assert.Equal(t, TrustTierNone, *ar.Submods["test"].Status)
@@ -293,7 +293,7 @@ func TestUpdateStatusFromTrustVector(t *testing.T) {
 func TestAsMap(t *testing.T) {
 	policyID := "foo"
 
-	ar := NewAttestationResult("someScheme")
+	ar := NewAttestationResult("someScheme", "test", "test")
 	status := NewTrustTier(TrustTierAffirming)
 	ar.Submods["someScheme"].Status = status
 	ar.Submods["someScheme"].TrustVector.Executables = ApprovedRuntimeClaim
@@ -370,4 +370,14 @@ func TestTrustTier_ColorString(t *testing.T) {
 	assert.Equal(t, "\\033[42maffirming\\033[0m", TrustTierAffirming.ColorString())
 	assert.Equal(t, "\\033[43mwarning\\033[0m", TrustTierWarning.ColorString())
 	assert.Equal(t, "\\033[41mcontraindicated\\033[0m", TrustTierContraindicated.ColorString())
+}
+
+func TestNewAttestationResult(t *testing.T) {
+	ar := NewAttestationResult("test", "testBuild", "testDev")
+
+	_, err := ar.MarshalJSON()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "testBuild", *ar.VerifierID.Build)
+	assert.Equal(t, "testDev", *ar.VerifierID.Developer)
 }


### PR DESCRIPTION
NewAttestationResult() has to initialize the VerifierID, is it is a mandatory filed. There is no reasonable default that can be supplied for it, so pass its values as parameters.