### PR TITLE
trusttier: add "identity" conversions to ToTrustTier

### DIFF
--- a/trusttier.go
+++ b/trusttier.go
@@ -152,6 +152,10 @@ func ToTrustTier(v interface{}) (*TrustTier, error) {
 				err = fmt.Errorf("not a valid TrustTier value: %v (%d)", t, int(i))
 			}
 		}
+	case TrustTier:
+		tier = t
+	case *TrustTier:
+		tier = *t
 	default:
 		err = fmt.Errorf("cannot convert %v (type %T) to TrustTier", t, t)
 	}

--- a/trusttier_test.go
+++ b/trusttier_test.go
@@ -163,4 +163,13 @@ func TestTrustTier_ToTrustTier(t *testing.T) {
 	tt, err = ToTrustTier(UnrecognizedHardwareClaim)
 	require.NoError(t, err)
 	assert.Equal(t, TrustTierContraindicated, *tt)
+
+	tt, err = ToTrustTier(TrustTierContraindicated)
+	require.NoError(t, err)
+	assert.Equal(t, TrustTierContraindicated, *tt)
+
+	taff := TrustTierAffirming
+	tt, err = ToTrustTier(&taff)
+	require.NoError(t, err)
+	assert.Equal(t, TrustTierAffirming, *tt)
 }


### PR DESCRIPTION
Allow TrustTier and *TrustTier as valid input types  for ToTrustTier(). This is something that already exists for ToTrustClaim and should have been implemented for ToTrustTier as well.