### PR TITLE
ear: update Nonce size limits in validate()

### DIFF
--- a/ear.go
+++ b/ear.go
@@ -154,7 +154,7 @@ func (o AttestationResult) validate() error {
 
 	if o.Nonce != nil {
 		nLen := len(*o.Nonce)
-		if nLen > 74 || nLen < 10 {
+		if nLen > 88 || nLen < 8 {
 			invalid = append(invalid, fmt.Sprintf("eat_nonce (%d bytes)", nLen))
 		}
 	}


### PR DESCRIPTION
Update Nonce size limits to align with the latest updates to the EAT draft:

https://github.com/ietf-rats-wg/eat/pull/421

This also helps ups deal with CCA which mandates realm challenge to be 64 bytes that would exceed the old size limit when base64 encoded.