### PR TITLE
fix(test): Work around new FIPS 186-4 behavior introduced in go 1.20

### DIFF
--- a/ear_appraisal_test.go
+++ b/ear_appraisal_test.go
@@ -15,11 +15,11 @@ import (
 func TestAppraisalExtensions_SetGetKeyAttestation_ok(t *testing.T) {
 	expected := AppraisalExtensions{
 		VeraisonKeyAttestation: &map[string]interface{}{
-			"akpub": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt6zOg9KE5RdiYwpZP40Li_hp_m47n60p8D54WK84zV2sxXs7LtkBoN79R9Q",
+			"akpub": "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqzDTRkrGv-0lBk2QEnnhpFsLdajD5MxKGCw29Yots81gYWDu5B-cSpxKzogNMlLG7t3tFYEZoYB_U4Pxtj4Wmw",
 		},
 	}
 
-	kp, err := ecdsa.GenerateKey(elliptic.P256(), new(zeroSource))
+	kp, err := ecdsa.GenerateKey(elliptic.P256(), new(xSource))
 	require.NoError(t, err)
 	tv := kp.Public()
 

--- a/test_utils.go
+++ b/test_utils.go
@@ -3,12 +3,12 @@
 
 package ear
 
-// zeroSource is an io.Reader that returns an unlimited number of zero bytes.
-type zeroSource struct{}
+// xSource is an io.Reader that returns an unlimited number of 'x' chars.
+type xSource struct{}
 
-func (zeroSource) Read(b []byte) (n int, err error) {
+func (xSource) Read(b []byte) (n int, err error) {
 	for i := range b {
-		b[i] = 0
+		b[i] = 'x'
 	}
 
 	return len(b), nil


### PR DESCRIPTION
For more context, see [1].

[1]  https://github.com/golang/go/issues/58454

Fix #37