### PR TITLE
fix: added status validation to ear_appraisal

### DIFF
--- a/ear.go
+++ b/ear.go
@@ -168,7 +168,7 @@ func (o AttestationResult) validate() error {
 		missing = append(missing, "'submods' (at least one appraisal must be present)")
 	} else {
 		for submodName, appraisal := range o.Submods {
-			if err := appraisal.validate(); err != nil {
+			if err := appraisal.Validate(); err != nil {
 				msg := fmt.Sprintf("submods[%s]: %s", submodName, err.Error())
 				invalid = append(invalid, msg)
 			}

--- a/ear_appraisal.go
+++ b/ear_appraisal.go
@@ -110,6 +110,10 @@ func (o AppraisalExtensions) GetKeyAttestation() (any, error) {
 // individual vector claims (though it could be less trustworthy if had been
 // manually set that way).
 func (o *Appraisal) UpdateStatusFromTrustVector() {
+	if o.TrustVector == nil {
+		return
+	}
+
 	for _, claimValue := range o.TrustVector.AsMap() {
 		claimTier := claimValue.GetTier()
 		if *o.Status < claimTier {
@@ -131,9 +135,34 @@ func (o Appraisal) AsMap() map[string]interface{} {
 	return m
 }
 
-func (o Appraisal) validate() error {
+// Validate makes sure that the value of status is indeed
+// greater than or equal to all elements of the trust vector.
+// This makes sure that it is always less trustworthy than the
+// trust vector components
+func (o Appraisal) Validate() error {
 	if o.Status == nil {
 		return errors.New("missing mandatory 'ear.status'")
+	}
+
+	// guarantee that status is one of the four trust tiers
+	switch *o.Status {
+	case TrustTierNone:
+	case TrustTierAffirming:
+	case TrustTierWarning:
+	case TrustTierContraindicated:
+	default:
+		return fmt.Errorf("'ear.status' must be a valid trust tier, but is: %d", *o.Status)
+	}
+
+	if o.TrustVector == nil {
+		return nil
+	}
+
+	for key, claimValue := range o.TrustVector.AsMap() {
+		claimTier := claimValue.GetTier()
+		if *o.Status < claimTier {
+			return fmt.Errorf("status %d has higher trustworthiness than %s trust vector element(%d)", *o.Status, key, claimTier)
+		}
 	}
 
 	return nil

--- a/ear_appraisal_test.go
+++ b/ear_appraisal_test.go
@@ -101,3 +101,89 @@ func TestNewAppraisal(t *testing.T) {
 		assert.Equal(t, NoClaim, claim)
 	}
 }
+
+func TestAppraisal_UpdateStatusFromTrustVector_new(t *testing.T) {
+	appraisal := NewAppraisal()
+
+	appraisal.UpdateStatusFromTrustVector()
+
+	assert.Equal(t, TrustTier(0), *appraisal.Status)
+}
+
+func TestAppraisal_UpdateStatusFromTrustVector_basic(t *testing.T) {
+	appraisal := NewAppraisal()
+	trustVector := TrustVector{
+		InstanceIdentity: -2,
+		Configuration:    54,
+	}
+	appraisal.TrustVector = &trustVector
+
+	appraisal.UpdateStatusFromTrustVector()
+
+	assert.Equal(t, TrustTierWarning, *appraisal.Status)
+}
+
+func TestAppraisal_UpdateStatusFromTrustVector_respects_negative(t *testing.T) {
+	appraisal := NewAppraisal()
+	trustVector := TrustVector{
+		InstanceIdentity: -2,
+		Configuration:    5,
+		FileSystem:       54,
+		Hardware:         -97,
+	}
+	appraisal.TrustVector = &trustVector
+
+	appraisal.UpdateStatusFromTrustVector()
+
+	assert.Equal(t, TrustTierContraindicated, *appraisal.Status)
+}
+
+func TestAppraisal_Validate_nil(t *testing.T) {
+	appraisal := Appraisal{}
+	assert.Error(t, appraisal.Validate(), "missing mandatory 'ear.status'")
+}
+
+func TestAppraisal_Validate_new(t *testing.T) {
+	appraisal := NewAppraisal()
+	assert.Nil(t, appraisal.Validate())
+}
+
+func TestAppraisal_Validate_basic(t *testing.T) {
+	appraisal := NewAppraisal()
+	trustVector := TrustVector{
+		InstanceIdentity: -2,
+		Configuration:    5,
+		Hardware:         32,
+	}
+	appraisal.TrustVector = &trustVector
+	assert.Error(t, appraisal.Validate(), "status 0 has higher trustworthiness than InstanceIdentity trust vector element(2)")
+
+	appraisal.Status = new(TrustTier(2))
+	assert.Error(t, appraisal.Validate(), "status 2 has higher trustworthiness than Hardware trust vector element(32)")
+
+	appraisal.Status = new(TrustTier(32))
+	assert.Nil(t, appraisal.Validate())
+
+	appraisal.Status = new(TrustTier(33))
+	assert.Error(t, appraisal.Validate(), "'ear.status' must be a valid trust tier, but is: 33")
+}
+
+func TestAppraisal_Validate_respects_negative(t *testing.T) {
+	appraisal := NewAppraisal()
+	trustVector := TrustVector{
+		InstanceIdentity: -2,
+		Configuration:    1,
+		Hardware:         -54,
+	}
+	appraisal.TrustVector = &trustVector
+	assert.Error(t, appraisal.Validate(), "status 0 has higher trustworthiness than InstanceIdentity trust vector element(2)")
+
+	appraisal.Status = new(TrustTier(2))
+	assert.Error(t, appraisal.Validate(), "status 2 has higher trustworthiness than Hardware trust vector element(32)")
+
+	appraisal.Status = new(TrustTier(32))
+	assert.Nil(t, appraisal.Validate())
+
+	appraisal.Status = new(TrustTier(96))
+	assert.Nil(t, appraisal.Validate())
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veraison/ear
 
-go 1.23.0
+go 1.26
 
 toolchain go1.24.4
 


### PR DESCRIPTION
Contributes towards fixing veraison/services#430. Adds functionality to ear_appraisal.Validate() to check that the appraisal conforms to draft-fv-rats-ear-04. Thus, it is checked that:
 - status is one of the four defined trust tiers
 - status is larger than or equal to the trust tier of each element of the trust vector (= of no higher trustworthiness than the trust vector)

Additionally:
 - adds minimal unit tests to Validate() and UpdateStatusFromTrustVector()
 - adds not-nil check for trust vector to UpdateStatusFromTrustVector()
 - exports ear_appraisal.Validate(), such that it could be called when policies are validated